### PR TITLE
feat(package): add package.json to register plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "fastify-diagnostics-channel",
+  "version": "0.0.0",
+  "description": "Plugin to deal with diagnostics_channel on Fastify",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastify/fastify-diagnostics-channel.git"
+  },
+  "keywords": [],
+  "author": "Fastify Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/fastify/fastify-diagnostics-channel/issues"
+  },
+  "homepage": "https://github.com/fastify/fastify-diagnostics-channel#readme"
+}


### PR DESCRIPTION
Add package.json and also I registered the plugin on npm registry.﻿

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

