### PR TITLE
ci(package-manager): replace use of soon-to-be removed ubuntu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [15]
+        node-version: [15, 16]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     name: Node ${{ matrix.node-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: Continuous Integration
 on:
   push:
     paths-ignore:
-      - "*.md"
+      - '*.md'
   pull_request:
     paths-ignore:
-      - "*.md"
+      - '*.md'
 
 jobs:
   build:

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # Maintenance and active LTS
         node-version: [10, 12, 14, 16]
-        os: [ubuntu-16.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -42,7 +42,7 @@ jobs:
       matrix:
         # Maintenance and active LTS
         node-version: [10, 12, 14, 16]
-        os: [ubuntu-16.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [10, 12, 14, 16]
+        node-version: [16]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Maintenance and active LTS
-        node-version: [10, 12, 14, 16]
+        node-version: [16]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -2,8 +2,11 @@ name: package-manager-ci
 
 on:
   push:
-    branches:
-      - master
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - '*.md'
 
 jobs:
   pnpm:

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -2,6 +2,8 @@ name: package-manager-ci
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - '*.md'
   pull_request:


### PR DESCRIPTION
`ubuntu-16.04` will be removed as a runner this year: [see GitHub Blog here](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
