### PR TITLE
Rename module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fastify-diagnostics-channel",
-  "version": "1.0.0",
+  "name": "@fastify/diagnostics-channel",
+  "version": "2.0.0",
   "description": "Plugin to deal with diagnostics_channel on Fastify",
   "main": "lib/index.js",
   "directories": {
@@ -37,5 +37,8 @@
   },
   "engines": {
     "node": ">=15.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request renames the module according to the discussion in
https://github.com/fastify/fastify/issues/3733.

Note that the deprecation module has _already been published_ and that the
code for it does not exist in this repository. The code for the published
deprecation module was generated by https://github.com/fastify/deprecate-modules
and run on @jsumners local system.

Coordinating the drastic changes to the code for the module deprecation and
then restoring the code for the module renaming would have been extremely
difficult and prohibitively tedious.

**Important:** no further releases should be added to the old major version.
