### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The channels are prefixed by: `fastify.{HOOK_NAME}`
 This event is sent at every route registered passing a `routeOptions` object
 
 ```js
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 const onRoute = dc.channel('fastify.onRoute')
 
 onRoute.subscribe((routeOptions) => {
@@ -61,7 +61,7 @@ onRoute.subscribe((routeOptions) => {
 This event is sent at every response sent by server, it propagates an object containing: [`request` object](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`reply` object](https://github.com/fastify/fastify/blob/master/docs/Reply.md)
 
 ```js
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 const onResponse = dc.channel('fastify.onResponse')
 
 onResponse.subscribe((data) => {
@@ -79,7 +79,7 @@ This event is sent when some error is throw on the [lifecycle](https://www.fasti
 The message data is an object containing a [`request` object](https://github.com/fastify/fastify/blob/master/docs/Request.md), [`reply` object](https://github.com/fastify/fastify/blob/master/docs/Reply.md), and Error object
 
 ```js
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 const onError = dc.channel('fastify.onError')
 
 onError.subscribe((data) => {
@@ -100,7 +100,7 @@ The message data is an object containing a [`request` object](https://github.com
 Note: by default the Fastify does not limit the request time.
 
 ```js
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 const onTimeout = dc.channel('fastify.onTimeout')
 
 onTimeout.subscribe((data) => {
@@ -117,7 +117,7 @@ onTimeout.subscribe((data) => {
 This event is sent when a request is received; the message data is an object containing a [`request` object](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`reply` object](https://github.com/fastify/fastify/blob/master/docs/Reply.md)
 
 ```js
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 const onRequest = dc.channel('fastify.onRequest')
 
 onRequest.subscribe((data) => {

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,5 +1,5 @@
 const fastify = require('fastify')({ logger: true, connectionTimeout: 2000 })
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 
 const channels = [
   dc.channel('fastify.onRoute'),

--- a/lib/channels.js
+++ b/lib/channels.js
@@ -1,4 +1,4 @@
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 
 module.exports = {
   onRouteChannel: dc.channel('fastify.onRoute'),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,9 +3,9 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const dcPlugin = require('../lib/index')
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 const sget = require('simple-get').concat
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const pget = promisify(sget)
 
 test('Should call publish when route is registered', async t => {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
