### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "simple-get": "^4.0.1",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.